### PR TITLE
Add a toggler of nvtx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,11 @@ def main():
         description="Minimal Example of a C++/Python Extension with CMake, Unit Testing, and Documentation",
         author='William Ruys',
         author_email="will@oden.utexas.edu",
-        packages=["parla", "parla.cython", "parla.common"],
+        packages=["parla", "parla.cython", "parla.common", "parla.utility"],
         package_dir={"parla": "src/python/parla",
                      "parla.cython": "src/python/parla/cython",
-                     "parla.common": "src/python/parla/common"},
+                     "parla.common": "src/python/parla/common",
+                     "parla.utility": "src/python/parla/utility"},
         python_requires=">=3.8",
         cmake_args=cmake_args
     )

--- a/src/python/parla/common/containers.py
+++ b/src/python/parla/common/containers.py
@@ -4,8 +4,6 @@ from parla.cython import tasks
 TaskAwaitTasks = tasks.TaskAwaitTasks
 TaskID = tasks.TaskID
 
-import nvtx
-
 class TaskSet(Awaitable, Collection):
 
     def __init__(self, tasks):

--- a/src/python/parla/common/spawn.py
+++ b/src/python/parla/common/spawn.py
@@ -1,12 +1,11 @@
 from parla.common import containers
 from parla.cython import scheduler
 from parla.cython import core
+from parla.utility import nvtx_tracer
 
 import inspect
 
 from parla.cython import tasks
-
-import nvtx
 
 TaskID = tasks.TaskID
 task_locals = tasks.task_locals
@@ -16,6 +15,7 @@ _task_callback = scheduler._task_callback
 get_scheduler_context = scheduler.get_scheduler_context
 
 Tasks = containers.Tasks
+nvtx = nvtx_tracer.nvtx_tracer()
 
 Resources = core.Resources
 

--- a/src/python/parla/cython/core.pyx
+++ b/src/python/parla/cython/core.pyx
@@ -1,4 +1,3 @@
-import nvtx
 import cython 
 
 

--- a/src/python/parla/cython/scheduler.pyx
+++ b/src/python/parla/cython/scheduler.pyx
@@ -17,11 +17,12 @@ TaskID = tasks.TaskID
 Task = tasks.Task
 ComputeTask = tasks.ComputeTask
 
-import nvtx
+from parla.utility import nvtx_tracer
 
 PyInnerScheduler = core.PyInnerScheduler
 PyInnerWorker = core.PyInnerWorker
 PyInnerTask = core.PyInnerTask
+nvtx = nvtx_tracer.nvtx_tracer()
 
 class TaskBodyException(RuntimeError):
     pass

--- a/src/python/parla/cython/tasks.pyx
+++ b/src/python/parla/cython/tasks.pyx
@@ -10,8 +10,6 @@ import threading
 import traceback
 import sys
 
-import nvtx
-
 class TaskState(object, metaclass=ABCMeta):
     __slots__ = []
 

--- a/src/python/parla/utility/nvtx_tracer.py
+++ b/src/python/parla/utility/nvtx_tracer.py
@@ -1,5 +1,9 @@
 class nvtx_tracer:
-
+    """
+    This is a wrapper class of Python nvtx.
+    (https://docs.nvidia.com/nsight-visual-studio-edition/2020.1/nvtx/index.html)
+    If the nvtx package is not installed, convert nvtx calls to no-ops.
+    """
     def __init__(self):
         try:
             import nvtx

--- a/src/python/parla/utility/nvtx_tracer.py
+++ b/src/python/parla/utility/nvtx_tracer.py
@@ -1,0 +1,24 @@
+class nvtx_tracer:
+
+    def __init__(self):
+        try:
+            import nvtx
+            self.nvtx = nvtx
+            print("NVTX is enabled", flush=True)
+        except ImportError:
+            print("NVTX is disabled", flush=True)
+            self.nvtx = None
+
+    def __getattr__(self, name):
+        if self.nvtx is not None:
+            return getattr(self.nvtx, name)
+        else:
+            return "NVTX is not installed."
+
+    def push_range(self, message=None, color="blue", domain=None):
+        if self.nvtx is not None:
+            self.nvtx.push_range(message, color, domain)
+
+    def pop_range(self, domain=None):
+        if self.nvtx is not None:
+            self.nvtx.pop_range(domain)


### PR DESCRIPTION
It makes nvtx push/pop ranges no-ops if users do not have (or installed) the nvtx module. 
TODO: it seems like there is a compatibitliy issue too here. As a test, I installed nvtx-0.2.5, but it didn't find push_range() and pop_range(). So we need a version specification somewhere. 

TODO: I need to add comments on the nvtx_tracer. Will do.