### PR TITLE
Replace some pointers with shared_ptr and make a baseline of a mapping policy

### DIFF
--- a/src/c/backend/device_manager.cpp
+++ b/src/c/backend/device_manager.cpp
@@ -1,6 +1,5 @@
 #include "include/device_manager.hpp"
-#include <iostream>
 
-void DeviceManager::RegisterDevice(Device *new_dev) {
-  registered_devices_.emplace_back(*new_dev);
+void DeviceManager::RegisterDevice(Device* new_dev) {
+  registered_devices_.emplace_back(new_dev);
 }

--- a/src/c/backend/include/device_manager.hpp
+++ b/src/c/backend/include/device_manager.hpp
@@ -3,10 +3,8 @@
 #define PARLA_DEVICE_MANAGER_HPP
 
 #include "device.hpp"
-#include <iostream>
-#include <string>
-#include <unordered_map>
 
+#include <iostream>
 #include <vector>
 
 using DevID_t = uint32_t;
@@ -16,48 +14,32 @@ using DevID_t = uint32_t;
 class DeviceManager {
 public:
   DeviceManager() {}
-  void RegisterDevice(Device *new_dev);
+  DeviceManager(const DeviceManager&) = delete;
+  void RegisterDevice(Device* new_dev);
 
   void PrintRegisteredDevices() {
-    // std::cout << "C++ device list:\n";
+    std::cout << "C++ device list:\n";
     for (size_t d = 0; d < this->registered_devices_.size(); ++d) {
-      Device &dev = this->registered_devices_[d];
-      // std::cout << "[" << dev.GetName() << "] mem. sz:" <<
-      //   dev.GetMemorySize() << ", num. vcus:" << dev.GetNumVCUs() << "\n";
+      Device &dev = *(this->registered_devices_[d]);
+      std::cout << "[" << dev.GetName() << "] mem. sz:" <<
+        dev.GetMemorySize() << ", num. vcus:" << dev.GetNumVCUs() << "\n";
     }
   }
 
-  std::vector<Device> &GetAllDevices() { return registered_devices_; }
+  std::vector<Device*>& GetAllDevices() { return registered_devices_; }
 
-#if 0
-  ResourceRequirement* CreateResourceRequirement(Device* dev, DeviceResources req) {
-    // TODO(hc): This can be known at Python.
-    //           Later get this information from Python.
-    size_t num_archs = 2;
-    DeviceType dev_type;
-    std::vector<bool> has_arch_constraint(num_archs);
-    if (typeid(*dev) == typeid(CUDADevice)) {
-      dev_type = CUDA;
-      has_arch_constraint[dev_type] = 1;
-    } else if (typeid(*dev) == typeid(CPUDevice)) {
-      dev_type = CPU;
-      has_arch_constraint[dev_type] = 1;
+  ~DeviceManager() {
+    for (Device* d : registered_devices_) {
+      if (d != nullptr) {
+        delete d;
+      }
     }
-
-    std::vector<std::vector<Device*>> dev_ptr_vec(num_archs);
-    dev_ptr_vec[dev_type].emplace_back(dev);
-
-    std::vector<DeviceResources> req_vec;
-    req_vec.emplace_back(req);
-    return new ResourceRequirement(has_arch_constraint,
-                                   dev_ptr_vec, req_vec);
   }
-#endif
 
 private:
   // TODO(hc): This should use a vector of vector and
   //           the outer vector should be architecture type.
-  std::vector<Device> registered_devices_;
+  std::vector<Device*> registered_devices_;
 };
 
 #endif

--- a/src/c/backend/include/phases.hpp
+++ b/src/c/backend/include/phases.hpp
@@ -6,8 +6,10 @@
 #include "device.hpp"
 #include "device_manager.hpp"
 #include "runtime.hpp"
+#include "policy.hpp"
 
-#include <string.h>
+#include <string>
+#include <memory>
 
 class PhaseStatus {
 protected:
@@ -73,8 +75,10 @@ public:
   Map::Status status;
   Mapper() : SchedulerPhase(), dummy_dev_idx_{0} {}
 
-  Mapper(InnerScheduler *scheduler, DeviceManager *devices)
-      : SchedulerPhase(scheduler, devices), dummy_dev_idx_{0} {}
+  Mapper(InnerScheduler *scheduler, DeviceManager *devices, 
+         std::shared_ptr<MappingPolicy> policy) :
+          SchedulerPhase(scheduler, devices),
+          dummy_dev_idx_{0}, policy_{policy} {}
 
   void enqueue(InnerTask *task);
   void enqueue(std::vector<InnerTask *> &tasks);
@@ -86,6 +90,8 @@ protected:
   TaskQueue mappable_tasks;
   std::vector<InnerTask *> mapped_tasks_buffer;
   uint64_t dummy_dev_idx_;
+
+  std::shared_ptr<MappingPolicy> policy_;
 };
 
 namespace Reserved {

--- a/src/c/backend/include/policy.hpp
+++ b/src/c/backend/include/policy.hpp
@@ -1,0 +1,19 @@
+#ifndef PARLA_POLICY_HPP
+#define PARLA_POLICY_HPP
+
+#include "device.hpp"
+#include "runtime.hpp"
+
+#include <memory>
+
+class MappingPolicy {
+public:
+  virtual void MapTask(InnerTask*, const Device&) = 0;
+};
+
+class LocalityLoadBalancingMappingPolicy : public MappingPolicy {
+public:
+  void MapTask(InnerTask*, const Device&) override;
+};
+
+#endif

--- a/src/c/backend/include/resource_requirements.hpp
+++ b/src/c/backend/include/resource_requirements.hpp
@@ -3,6 +3,8 @@
 
 #include "device.hpp"
 
+#include <memory>
+
 /// Base classes.
 
 class DeviceRequirementBase {
@@ -17,23 +19,24 @@ class SingleDeviceRequirementBase : public DeviceRequirementBase {};
 /// memory and virtual computation units.
 class ResourceRequirementCollections {
 public:
-  void AppendDeviceRequirementOption(DeviceRequirementBase *dev_req);
-  const std::vector<DeviceRequirementBase *> &GetDeviceRequirementOptions();
+  void AppendDeviceRequirementOption(std::shared_ptr<DeviceRequirementBase> dev_req);
+  const std::vector<std::shared_ptr<DeviceRequirementBase>>& GetDeviceRequirementOptions();
 
 private:
-  std::vector<DeviceRequirementBase *> dev_reqs_;
+  std::vector<std::shared_ptr<DeviceRequirementBase>> dev_reqs_;
 };
 
 class MultiDeviceRequirements : public DeviceRequirementBase {
 public:
-  void AppendDeviceRequirement(SingleDeviceRequirementBase *req);
-  const std::vector<SingleDeviceRequirementBase *> &GetDeviceRequirements();
+  void AppendDeviceRequirement(std::shared_ptr<SingleDeviceRequirementBase> req);
   bool is_multidev_req() override { return true; }
   bool is_arch_req() override { return false; }
   bool is_dev_req() override { return false; }
 
+  const std::vector<std::shared_ptr<SingleDeviceRequirementBase>>& GetDeviceRequirements();
+
 private:
-  std::vector<SingleDeviceRequirementBase *> dev_reqs_;
+  std::vector<std::shared_ptr<SingleDeviceRequirementBase>> dev_reqs_;
 };
 
 class DeviceRequirement : public SingleDeviceRequirementBase {
@@ -45,25 +48,25 @@ public:
   bool is_arch_req() override { return false; }
   bool is_dev_req() override { return true; }
 
-  const Device &device() { return (*dev_); }
+  Device* device() { return dev_; }
 
-  const ResourcePool_t &res_req() { return res_reqs_; }
+  const ResourcePool_t& res_req() { return res_reqs_; }
 
 private:
-  Device *dev_;
+  Device* dev_;
   ResourcePool_t res_reqs_;
 };
 
 class ArchitectureRequirement : public SingleDeviceRequirementBase {
 public:
-  void AppendDeviceRequirementOption(DeviceRequirement *req);
-  const std::vector<DeviceRequirement *> &GetDeviceRequirementOptions();
+  void AppendDeviceRequirementOption(std::shared_ptr<DeviceRequirement> req);
+  const std::vector<std::shared_ptr<DeviceRequirement>>& GetDeviceRequirementOptions();
   bool is_multidev_req() override { return false; }
   bool is_arch_req() override { return true; }
   bool is_dev_req() override { return false; }
 
 private:
-  std::vector<DeviceRequirement *> dev_reqs_;
+  std::vector<std::shared_ptr<DeviceRequirement>> dev_reqs_;
 };
 
 #endif

--- a/src/c/backend/include/runtime.hpp
+++ b/src/c/backend/include/runtime.hpp
@@ -220,7 +220,6 @@ public:
   InnerTask();
   InnerTask(long long int id, void *py_task);
   InnerTask(std::string name, long long int id, void *py_task);
-  ~InnerTask();
 
   /* Set the scheduler */
   void set_scheduler(InnerScheduler *scheduler);
@@ -375,8 +374,8 @@ protected:
     MultiDevAdd = 3
   };
   uint32_t req_addition_mode_;
-  ArchitectureRequirement *tmp_arch_req_;
-  MultiDeviceRequirements *tmp_multdev_reqs_;
+  std::shared_ptr<ArchitectureRequirement> tmp_arch_req_;
+  std::shared_ptr<MultiDeviceRequirements> tmp_multdev_reqs_;
   ResourceRequirementCollections dev_res_reqs_;
 };
 
@@ -523,6 +522,8 @@ class Mapper;
 class MemoryReserver;
 class RuntimeReserver;
 class Launcher;
+class MappingPolicy;
+class LocalityLoadBalancingMappingPolicy;
 
 namespace Scheduler {
 
@@ -609,7 +610,6 @@ public:
   Launcher *launcher;
 
   InnerScheduler(DeviceManager *device_manager);
-  ~InnerScheduler();
   // InnerScheduler(int nworkers);
 
   /* Pointer to callback to stop the Python scheduler */
@@ -701,6 +701,8 @@ public:
   void spawn_wait();
 
 protected:
+  /// This manager manages all device instances in C++.
+  /// This is destructed by the Cython scheduler.
   DeviceManager *device_manager_;
 };
 

--- a/src/c/backend/policy.cpp
+++ b/src/c/backend/policy.cpp
@@ -1,0 +1,5 @@
+#include "include/policy.hpp"
+
+void LocalityLoadBalancingMappingPolicy::MapTask(InnerTask*, const Device&) {
+  std::cout << "Locality-aware- and Load-balancing mapping policy\n";
+}

--- a/src/c/backend/resource_requirements.cpp
+++ b/src/c/backend/resource_requirements.cpp
@@ -1,32 +1,32 @@
 #include "include/resource_requirements.hpp"
 
 void ResourceRequirementCollections::AppendDeviceRequirementOption(
-    DeviceRequirementBase* req) {
-  dev_reqs_.emplace_back(req);
+    std::shared_ptr<DeviceRequirementBase> req) {
+  dev_reqs_.emplace_back(std::shared_ptr<DeviceRequirementBase>(req));
 }
 
-const std::vector<DeviceRequirementBase*>&
+const std::vector<std::shared_ptr<DeviceRequirementBase>>&
     ResourceRequirementCollections::GetDeviceRequirementOptions() {
   return dev_reqs_;
 }
 
 void MultiDeviceRequirements::AppendDeviceRequirement(
-    SingleDeviceRequirementBase* req) {
-  dev_reqs_.emplace_back(req);
+    std::shared_ptr<SingleDeviceRequirementBase> req) {
+  dev_reqs_.emplace_back(std::shared_ptr<SingleDeviceRequirementBase>(req));
 }
 
-const std::vector<SingleDeviceRequirementBase*>&
+const std::vector<std::shared_ptr<SingleDeviceRequirementBase>>&
     MultiDeviceRequirements::GetDeviceRequirements() {
   return dev_reqs_;
 }
 
 void ArchitectureRequirement::AppendDeviceRequirementOption(
-    DeviceRequirement* req) {
-  dev_reqs_.emplace_back(req);
+    std::shared_ptr<DeviceRequirement> req) {
+  dev_reqs_.emplace_back(std::shared_ptr<DeviceRequirement>(req));
 }
 
 
-const std::vector<DeviceRequirement*>&
+const std::vector<std::shared_ptr<DeviceRequirement>>&
 ArchitectureRequirement::GetDeviceRequirementOptions() {
   return dev_reqs_;
 }

--- a/src/c/backend/scheduler.cpp
+++ b/src/c/backend/scheduler.cpp
@@ -1,4 +1,5 @@
 #include "include/phases.hpp"
+#include "include/policy.hpp"
 #include "include/resources.hpp"
 #include "include/runtime.hpp"
 
@@ -131,17 +132,17 @@ InnerScheduler::InnerScheduler(DeviceManager *device_manager)
 
   this->workers.set_num_workers(1);
 
+  // Mapping policy
+  std::shared_ptr<LocalityLoadBalancingMappingPolicy> mapping_policy =
+      std::make_shared<LocalityLoadBalancingMappingPolicy>();
+
   // Initialize the phases
-  this->mapper = new Mapper(this, device_manager);
+  this->mapper = new Mapper(this, device_manager, std::move(mapping_policy));
   this->memory_reserver = new MemoryReserver(this, device_manager);
   this->runtime_reserver = new RuntimeReserver(this, device_manager);
   this->launcher = new Launcher(this, device_manager);
   this->resources = new ResourcePool<std::atomic<int64_t>>();
   // TODO: Clean these up
-}
-
-InnerScheduler::~InnerScheduler() {
-  delete device_manager_;
 }
 
 void InnerScheduler::set_num_workers(int nworkers) {

--- a/src/python/parla/cython/device.pyx
+++ b/src/python/parla/cython/device.pyx
@@ -12,9 +12,6 @@ cdef class CyDevice:
     """
     A bridge between pure Python and C++ device objects.
     """
-    def __dealloc__(self):
-        del self._cpp_device
-
     cdef Device* get_cpp_device(self):
         return self._cpp_device
 
@@ -24,7 +21,8 @@ cdef class CyCUDADevice(CyDevice):
     An inherited class from `CyDevice` for a device object specialized to CUDA.
     """
     def __cinit__(self, int dev_id, long mem_sz, long num_vcus, py_device):
-        # This object will be deallocated at CyDevice's dealloc().
+        # C++ device object.
+        # This object is deallocated by the C++ device manager.
         self._cpp_device = new CUDADevice(dev_id, mem_sz, num_vcus, \
                                           <void *> py_device)
 
@@ -37,7 +35,8 @@ cdef class CyCPUDevice(CyDevice):
     An inherited class from `CyDevice` for a device object specialized to CPU.
     """
     def __cinit__(self, int dev_id, long mem_sz, long num_vcus, py_device):
-        # This object will be deallocated at CyDevice's dealloc().
+        # C++ device object.
+        # This object is deallocated by the C++ device manager.
         self._cpp_device = new CPUDevice(dev_id, mem_sz, num_vcus, \
                                          <void *> py_device)
 


### PR DESCRIPTION
This PR replaces some pointers with shared_ptr to automate and ease deallocations.
I failed to replace Device pointers with the smart pointers since the current Cython supports shared_ptr, but does not support an assignment of a shared_ptr of an inherited class to the one of the base class. Through these changes, this PR needed to remove some manual destructors to avoid double free aborts. 