### PR TITLE
Make user input for VCUs consistent with Parla 0.2

### DIFF
--- a/src/c/backend/include/phases.hpp
+++ b/src/c/backend/include/phases.hpp
@@ -183,10 +183,6 @@ protected:
   void reserve_resources(InnerTask *task);
 };
 
-#ifdef PARLA_ENABLE_LOGGING
-LOG_ADAPT_STRUCT(RuntimeReserver, print_status)
-#endif
-
 class Launcher : virtual public SchedulerPhase {
 public:
   /*Number of running tasks. A task is running if it has been assigned to a

--- a/src/python/parla/common/spawn.py
+++ b/src/python/parla/common/spawn.py
@@ -25,6 +25,8 @@ nvtx.initialize()
 
 Resources = core.Resources
 
+VCU_BASELINE = device_manager.VCU_BASELINE
+
 # @profile
 
 
@@ -72,6 +74,14 @@ def spawn(task=None,
         nonlocal dependencies
         nonlocal task
         nonlocal placement
+
+        if not isinstance(vcus, int):
+            # Default behavior the same as Parla 0.2.
+            if vcus <= 1:
+                vcus = int(vcus * VCU_BASELINE)
+            else:
+                # Only large values for ease of testing
+                vcus = int(vcus)
 
         if inspect.iscoroutine(body):
             separated_body = body


### PR DESCRIPTION
Truncates VCUs as a part of 1000 when given as a non-integer type. 
This maintains the ability to use integers directly as a part of 1000 for testing. 