### PR TITLE
Disable memory locality normalization (like the old Parla) and refactor policy part

### DIFF
--- a/src/c/backend/include/policy.hpp
+++ b/src/c/backend/include/policy.hpp
@@ -94,6 +94,13 @@ public:
           std::vector<std::pair<parray::InnerPArray *, AccessMode>>>
           &parray_list) = 0;
 
+  virtual bool run_task_mapping(
+      InnerTask *task, const Mapper &mapper,
+      std::vector<std::shared_ptr<DeviceRequirement>> *chosen_devices,
+      const std::vector<std::vector<std::pair<parray::InnerPArray *, AccessMode>>>
+          &parray_list,
+      std::vector<std::shared_ptr<PlacementRequirementBase>> *placement_req_options_vec) = 0;
+
 protected:
   DeviceManager *device_manager_;
   PArrayTracker *parray_tracker_;
@@ -127,6 +134,13 @@ public:
       const std::vector<
           std::vector<std::pair<parray::InnerPArray *, AccessMode>>>
           &parray_list) override;
+
+  bool run_task_mapping(
+      InnerTask *task, const Mapper &mapper,
+      std::vector<std::shared_ptr<DeviceRequirement>> *chosen_devices,
+      const std::vector<std::vector<std::pair<parray::InnerPArray *, AccessMode>>>
+          &parray_list,
+      std::vector<std::shared_ptr<PlacementRequirementBase>> *placement_req_options_vec);
 };
 
 #endif

--- a/testing/python/test_task_mapping_policy_locality.py
+++ b/testing/python/test_task_mapping_policy_locality.py
@@ -41,7 +41,7 @@ def test_task_mapping_policy():
                 ctx = get_current_context()
                 assert ctx().get_global_id() == 4
 
-            @spawn(ts[4], placement=[(gpu(1), gpu(2)), (gpu(1), gpu(4)), (gpu(0), gpu(1)), (cpu(0), gpu(1)), (gpu(1), gpu(3))], dependencies=[ts[3]], input=[(a, 0), (b, 1)])
+            @spawn(ts[4], placement=[(gpu(1), gpu(2)), (gpu(1), gpu(3)), (gpu(0), gpu(1)), (cpu(0), gpu(1)), (gpu(1), gpu(3))], dependencies=[ts[3]], input=[(a, 0), (b, 1)])
             def t4():
                 devs = get_current_devices()
                 assert devs[0]().get_global_id() == 2


### PR DESCRIPTION
In the past, our runtime normalizes data locality by a device memory size.
But the device memory size is too big and data locality was usually ignored by load balancing even though that is more important.  This PR disables that normalization like the old Parla. Plus, this refactors the policy part and moves the main loop choosing the next device onto the policy. (So, we can get more modularization)