### PR TITLE
feat: update return value of parray evict()

### DIFF
--- a/src/python/parla/common/parray/coherence.py
+++ b/src/python/parla/common/parray/coherence.py
@@ -124,7 +124,7 @@ class Coherence:
         """
         for device_id in self._local_states.keys():
             self._local_states[device_id] = self.INVALID
-            self._versions[device_id] = None
+            self._versions[device_id] = -1
             self._is_complete[device_id] = None
         
         self._local_states[new_owner] = self.MODIFIED
@@ -456,9 +456,8 @@ class Coherence:
         Return:
             List[MemoryOperation], could return several MemoryOperations.
                 And the order operations matter.
-        Note: if this device has the last copy and `keep_one_copy` is false, 
-            the whole protocol state will be INVALID then.
-            And the system will lose the copy. Be careful when evict the last copy.
+            Or [ERROR] if this device has the last copy and `keep_one_copy` is false, 
+            since eviction cannot be performed.
         """
         device_local_state = self._local_states[device_id]
         operations = []
@@ -499,12 +498,7 @@ class Coherence:
                 else:
                     return [MemoryOperation.noop()]
             else:
-                self._global_state = self.INVALID  # the system lose the last copy
-                self.owner = None
-                self._versions[device_id] = -1
-                self._is_complete[device_id] = None
-
-                self._local_states[device_id] = self.INVALID
-                operations.append(MemoryOperation.evict(device_id))
+                # do nothing and report error
+                return [MemoryOperation.error()]
 
         return operations

--- a/testing/python/test_parray.py
+++ b/testing/python/test_parray.py
@@ -86,6 +86,17 @@ def test_parray_task():
                 assert a[-1] == 4
                 assert a._coherence.owner == 1
 
+            @spawn(ts[5], dependencies=[ts[4]], placement=gpu(1), inout=[(a,0)])
+            def check_array_update():
+                result = a.evict(1, False)
+
+                assert result == False
+
+                result = a.evict(1)
+
+                assert result == True
+                assert a._coherence.owner == -1
+
 if __name__=="__main__":
     test_parray_creation()
     test_parray_task()


### PR DESCRIPTION
      Evict a device's copy and update coherence states.

      Args:
          device_id: if is this not None, data will be moved to this device,
                  else move to current device
          keep_one_copy: if it is True and this is the last copy, 
                  write it back to CPU before evict.
      Return:
          true if the copy is evicted successfully
          false if the eviction cannot be performed since it has last copy
              and `keep_one_copy` is false