### PR TITLE
fix: fix bugs on changes of owner during eviction

### DIFF
--- a/testing/python/test_parray.py
+++ b/testing/python/test_parray.py
@@ -87,7 +87,10 @@ def test_parray_task():
                 assert a._coherence.owner == 1
 
             @spawn(ts[5], dependencies=[ts[4]], placement=gpu(1), inout=[(a,0)])
-            def check_array_update():
+            def check_array_evict():
+                a.print_overview()
+
+                print(a)
                 result = a.evict(1, False)
 
                 assert result == False
@@ -96,6 +99,17 @@ def test_parray_task():
 
                 assert result == True
                 assert a._coherence.owner == -1
+                assert a._array._buffer[1] is None
+
+            @spawn(ts[6], dependencies=[ts[5]], placement=gpu(0), input=[(a,0)])
+            def check_array_evict2():
+                assert a._array._buffer[-1] is not None
+                result = a.evict(-1, False)
+
+                assert result == True
+
+                assert a._coherence.owner == 0
+                assert a._array._buffer[-1] is None
 
 if __name__=="__main__":
     test_parray_creation()


### PR DESCRIPTION
Solve two bugs reported by @nicelhc13 

> ```
> At GPU 0: state: SHARED
> At GPU 1: state: INVALID
> At GPU 2: state: INVALID
> At GPU 3: state: INVALID
> At CPU: state: SHARED
> ```
> This was a state and I tried to call evict(0). But GPU 0 is considered as an owner, and no one was deallocated.

And

> Let's assume that I have a PArray like below:
> ```
> {0: array([[2, 3, 5, 6, 7],                                                          
>        [2, 3, 5, 6, 7],                                                              
>        [2, 3, 5, 6, 7],                                                              
>        [2, 3, 5, 6, 7]]), 1: None, 2: None, 3: None, -1: array([[2, 3, 5, 6, 7],     
>        [2, 3, 5, 6, 7],                                                              
>        [2, 3, 5, 6, 7],                                                              
>        [2, 3, 5, 6, 7]])} 
> ```                                                           
> And I called
> ```
> parray.evict(0);
> ```
> My expectation:
> ```
> {0: None, 1: None, 2: None, 3: None, -1: array([[2, 3, 5, 6, 7],     
>        [2, 3, 5, 6, 7],                                                              
>        [2, 3, 5, 6, 7],                                                              
>        [2, 3, 5, 6, 7]])}                                                            
> ```
> But:
> ```
> {0: array([[2, 3, 5, 6, 7],                                                          
>        [2, 3, 5, 6, 7],                                                              
>        [2, 3, 5, 6, 7],                                                              
>        [2, 3, 5, 6, 7]]), 1: None, 2: None, 3: None, -1: array([[2, 3, 5, 6, 7],     
>        [2, 3, 5, 6, 7],                                                              
>        [2, 3, 5, 6, 7],                                                              
>        [2, 3, 5, 6, 7]])}                                                            
> ```
> So the 0'th reference was not decreased.