### PR TITLE
Data Movement Tasks should only perform read operations.

### DIFF
--- a/src/c/backend/include/device_manager.hpp
+++ b/src/c/backend/include/device_manager.hpp
@@ -98,7 +98,7 @@ public:
 
   // TODO(hc): use a customized type for device id.
 
-  const DevID_t globalid_to_parrayid(DevID_t global_dev_id) const {
+  const int globalid_to_parrayid(unsigned int global_dev_id) const {
     Device *dev = all_devices_[global_dev_id];
     if (dev->get_type() == DeviceType::CPU) {
       return -1;
@@ -107,7 +107,7 @@ public:
     }
   }
 
-  const int parrayid_to_globalid(DevID_t parray_dev_id) const {
+  const unsigned int parrayid_to_globalid(int parray_dev_id) const {
     if (parray_dev_id == -1) {
       // XXX: This assumes that a CPU device is always single and
       //      is added at first.

--- a/src/python/parla/__init__.py
+++ b/src/python/parla/__init__.py
@@ -99,10 +99,10 @@ class Parla:
             self.original_handler = signal.getsignal(self.sig)
 
             def handler(signum, frame):
-                print("YOU PRESSED CTRL+C, INTERRUPTING ALL TASKS", flush=True)
+                print("Attempting to interurpt all running tasks...", flush=True)
                 self._sched.stop()
                 self.release()
-                self.interrupted = True
+                self.interuppted = True
 
             signal.signal(self.sig, handler)
         except ValueError:

--- a/src/python/parla/common/globals.py
+++ b/src/python/parla/common/globals.py
@@ -35,10 +35,6 @@ else:
 USE_PYTHON_RUNAHEAD = os.getenv("PARLA_ENABLE_PYTHON_RUNAHEAD", "1") == "1"
 PREINIT_THREADS = os.getenv("PARLA_PREINIT_THREADS", "1") == "1"
 
-print("USE_PYTHON_RUNAHEAD: ", USE_PYTHON_RUNAHEAD)
-print("CUPY_ENABLED: ", CUPY_ENABLED)
-print("PREINIT_THREADS: ", PREINIT_THREADS)
-
 _global_data_tasks = {}
 
 
@@ -65,8 +61,16 @@ elif SYNC_FLAG == "1":
 else:
     default_sync = SynchronizationType.NON_BLOCKING
 
-print("DEFAULT SYNC: ", default_sync)
 
+def print_config():
+    print("Parla Configuration", flush=True)
+    print("-------------------", flush=True)
+    print("Cupy Found: ", CUPY_ENABLED, flush=True)
+    print("Crosspy Found: ", CROSSPY_ENABLED, flush=True)
+    print("Preinitialize Cupy + Handles in Threads: ", PREINIT_THREADS, flush=True)
+    print("Runahead Scheduling Backend: ", USE_PYTHON_RUNAHEAD, flush=True)
+    print("Default Runahead Behavior: ", default_sync, flush=True)
+    print("VCU Precision: ", VCU_BASELINE, flush=True)
 
 class DeviceType(IntEnum):
     """

--- a/src/python/parla/common/parray/core.py
+++ b/src/python/parla/common/parray/core.py
@@ -217,6 +217,9 @@ class PArray:
 
     # Public API:
 
+    def set_name(self, name: str):
+        self._name = name
+
     def get(self, device: Optional[PyDevice] = None) -> 'np.ndarray' | 'cp.ndarray':
         if device is None:
             return self.array

--- a/src/python/parla/cython/device_manager.pxd
+++ b/src/python/parla/cython/device_manager.pxd
@@ -13,9 +13,8 @@ cdef extern from "include/device_manager.hpp" nogil:
         DeviceManager() except +
         void register_device(Device*) except +
         void print_registered_devices() except +
-        int globalid_to_parrayid(int) except +
-        int parrayid_to_globalid(int) except +
-
+        int globalid_to_parrayid(unsigned int) except +
+        unsigned int parrayid_to_globalid(int) except +
 
 cdef class CyDeviceManager:
     cdef DeviceManager* cpp_device_manager_

--- a/src/python/parla/cython/tasks.pyx
+++ b/src/python/parla/cython/tasks.pyx
@@ -714,8 +714,9 @@ class DataMovementTask(Task):
         Devices are given by the local relative device id within the TaskEnvironment.
         """
 
-        print(f"Running data movement task: {self.name}, {self.parray.name} {self.access_mode}", flush=True)
-        write_flag = True if self.access_mode != AccessMode.IN else False
+        # write_flag = True if self.access_mode != AccessMode.IN else False
+        # Data movement tasks should only perform read operations
+        write_flag = False 
 
         # TODO: Get device manager from task environment instead of scheduler at creation time
         device_manager = self.scheduler.device_manager

--- a/src/python/parla/cython/tasks.pyx
+++ b/src/python/parla/cython/tasks.pyx
@@ -713,6 +713,8 @@ class DataMovementTask(Task):
         @brief Run the data movement task. Calls the PArray interface to move the data to the assigned devices.
         Devices are given by the local relative device id within the TaskEnvironment.
         """
+
+        print(f"Running data movement task: {self.name}, {self.parray.name} {self.access_mode}", flush=True)
         write_flag = True if self.access_mode != AccessMode.IN else False
 
         # TODO: Get device manager from task environment instead of scheduler at creation time
@@ -720,7 +722,6 @@ class DataMovementTask(Task):
         target_dev = self.assigned_devices[0]
         global_id = target_dev.get_global_id()
         parray_id = device_manager.globalid_to_parrayid(global_id)
-
         self.parray._auto_move(parray_id, write_flag)
         return TaskRunahead(0)
 


### PR DESCRIPTION
Tasks that read and write to an array should be able to prefetch their data from a valid copy while other tasks are reading and using it. 

This fix prevents the updated dependencies from causing a write-invalidation during a prefetching step. 